### PR TITLE
Fjerner $ for å ha tilgang til attribut i klassen

### DIFF
--- a/controller/faktura.controller.php
+++ b/controller/faktura.controller.php
@@ -38,7 +38,7 @@ $INFOS['sms_invoice_threshold'] = get_site_option('UKMmateriell_sms_invoice_thre
 	$objPHPExcel->phpSpreadsheet->setActiveSheetIndex(0)->getTabColor()->setRGB('A0CF67');
 	
 	// exSheetName('Fakturagrunnlag');
-	$objPHPExcel->$sheet_names[] = 'Fakturagrunnlag';
+	$objPHPExcel->sheet_names[] = 'Fakturagrunnlag';
 	// HEADERS
 	$row = 1;
 


### PR DESCRIPTION
Fra PHP8: Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity